### PR TITLE
Add typing for asynchronous ActionCreator with no arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,17 +12,21 @@ export type ActionCreator<Input, Payload = Input> = {
   type: string;
 };
 
+type AsyncCallable<Input, Payload> = Input extends void
+  ? () => Promise<Payload>
+  : (input: Input) => Promise<Payload>;
+
 export type AsyncActionCreator<Input, Payload> = {
   started: ActionCreator<Input, void>;
   resolved: ActionCreator<Input, Payload>;
   rejected: ActionCreator<Input, Error>;
-} & ((input: Input) => Promise<Payload>);
+} & AsyncCallable<Input, Payload>;
 
 export type ThunkActionCreator<Input, A = any, R = any> = {
   started: ActionCreator<Input, void>;
   resolved: ActionCreator<Input, R>;
   rejected: ActionCreator<Input, Error>;
-} & ((input: Input) => void);
+} & AsyncCallable<Input, void>;
 
 // Reducer helper
 export type Reducer<State> = {

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -35,6 +35,16 @@ const thunked2 = createThunkAction<
   return { ret: true };
 });
 
+const thunkedNoArgs = createThunkAction(
+  "thunked-noargs",
+  async (_input: void, dispatch, getState) => {
+    dispatch(inc(0));
+    dispatch(dec(0));
+    dispatch(inc(0));
+    return getState();
+  }
+);
+
 const _type: string = inc.type;
 
 const incAsync = createAsyncAction("inc-async", async (val: number) => {
@@ -42,6 +52,15 @@ const incAsync = createAsyncAction("inc-async", async (val: number) => {
 });
 
 inc(1); //=> { type: 'counter/inc', payload: 1 }
+
+const asyncWithNoArgs = createAsyncAction(
+  "async-noargs",
+  async (_val: void) => {
+    return [1, 2, 3];
+  }
+);
+
+asyncWithNoArgs();
 
 type State = { value: number };
 
@@ -99,3 +118,4 @@ assert(ret1.value === 2);
 assert(inc(1).type === "counter/inc");
 
 thunked2({ value: 1 });
+thunkedNoArgs();


### PR DESCRIPTION
引数なしAsync & Thunk ActionCreatorの型定義サポート :pray: 

i.e.

```typescript
// thunk example
const thunkedNoArgs = createThunkAction(
  "thunked-noargs",
  async (_input: void, dispatch, getState) => {
    dispatch(inc(0));
    dispatch(dec(0));
    dispatch(inc(0));
    return getState();
  }
);

thunkedNoArgs();
```
