### PR TITLE
Fix reducer type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ export type ThunkActionCreator<Input, A = any, R = any> = {
 
 // Reducer helper
 export type Reducer<State> = {
-  (state: State, action: any): State;
+  (state: State | undefined, action: any): State;
   get: () => Reducer<State>;
   case<Input, Payload>(
     actionFunc: ActionCreator<Input, Payload>,


### PR DESCRIPTION
hard-reducer does not include undefined in State type

Type declaration of reducer in redux

```
export type Reducer<S = any, A extends Action = AnyAction> = (
  state: S | undefined,
  action: A
) => S
```

<img width="490" alt="2019-02-23 3 10 13" src="https://user-images.githubusercontent.com/5423775/53261979-c677e600-3718-11e9-8a7d-1654cf3b9248.png">
