### PR TITLE
Asyncの失敗をそのまま返すように修正

### DIFF
--- a/src/buildActionCreator.js
+++ b/src/buildActionCreator.js
@@ -41,9 +41,11 @@ export default function buildActionCreator(opts: { prefix?: string } = {}) {
         return Promise.resolve(fn(input, dispatch, getState))
           .then(payload => {
             dispatch({ type: resolved, payload });
+            return payload;
           })
           .catch(error => {
             dispatch({ type: rejected, payload: error, error: true });
+            return Promise.reject(error);
           });
       };
     };
@@ -80,9 +82,11 @@ export default function buildActionCreator(opts: { prefix?: string } = {}) {
         })
         .catch(err => {
           dispatch({
-            type: rejected
+            type: rejected,
+            payload: err,
+            error: true
           });
-          return err;
+          return Promise.reject(err);
         });
     };
 

--- a/test/async.js
+++ b/test/async.js
@@ -36,7 +36,10 @@ store.subscribe((...args) => {
 const test = async () => {
   await store.dispatch(incAsync(2));
   await store.dispatch(incAsync(4));
-  await store.dispatch(incAsync(13));
+  await store.dispatch(
+    incAsync(13)
+      .catch(err => console.log())
+);
 };
 
 test();


### PR DESCRIPTION
ついでにasyncActionCreatorがreducerにerrorオブジェクトを返却していなかったのを追加。

typescript-fsaなどのライブラリとの互換性をとって乗り換えコストを減らしたいというのが理由です。 🙏 